### PR TITLE
Update pulseaudio_backend.c

### DIFF
--- a/src/common/backend/pulseaudio_backend.c
+++ b/src/common/backend/pulseaudio_backend.c
@@ -94,7 +94,7 @@ int pulseaudio_open(audio_backend_handle_t handle, char const* device_name, char
         return -EINVAL;
     }
 
-    pulseaudio_backend->pulseaudio_handle = pa_simple_new(0, "vban", (direction == AUDIO_OUT) ? PA_STREAM_PLAYBACK : PA_STREAM_RECORD, (device_name[0] == '\0') ? 0 : device_name,
+    pulseaudio_backend->pulseaudio_handle = pa_simple_new(0, description, (direction == AUDIO_OUT) ? PA_STREAM_PLAYBACK : PA_STREAM_RECORD, (device_name[0] == '\0') ? 0 : device_name,
         (description[0] == '\0') ? ((direction == AUDIO_OUT) ? "playback" : "record") : description, &ss, 0, (direction == AUDIO_OUT) ? &ba : 0, &ret);
     if (pulseaudio_backend->pulseaudio_handle == 0)
     {


### PR DESCRIPTION
by default multiple instances will register with pulseaudio plain "vban". 
that means that the audio session manager cannot determine which is which and therefore not autoreconnect if more than one vban is running.
this change will now do what was advertised by the switch and set the "-D description" as a pulseaudio streamname - allowing now multiple vbans to be reconnected
and saves my  keyboard from lethal harm at the next reboot